### PR TITLE
 Update class to className in links of Bca, Bcom, and Business pages

### DIFF
--- a/src/pages/Bca.js
+++ b/src/pages/Bca.js
@@ -23,12 +23,12 @@ function Bca() {
               >
                 <span className="">Get Enroll</span>
                 <svg
-                className=""
+               
                   xmlns="http://www.w3.org/2000/svg"
                   width="16"
                   height="16"
                   fill="currentColor"
-                  class="bi bi-arrow-right-circle-fill"
+                  className="bi bi-arrow-right-circle-fill"
                   viewBox="0 0 16 16"
                 >
                   <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0M4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5z" />

--- a/src/pages/Bcom.js
+++ b/src/pages/Bcom.js
@@ -21,16 +21,16 @@ const Bcom = () => {
               </h1>
               <Link
                 to="/signup"
-                class="text-white flex justify-center gap-5 items-center bg-gradient-to-r   from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-3 text-center "
+                className="text-white flex justify-center gap-5 items-center bg-gradient-to-r   from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-3 text-center "
               >
                 <span className="">Get Enroll</span>
                 <svg
-                className=""
+               
                   xmlns="http://www.w3.org/2000/svg"
                   width="16"
                   height="16"
                   fill="currentColor"
-                  class="bi bi-arrow-right-circle-fill"
+                  className="bi bi-arrow-right-circle-fill"
                   viewBox="0 0 16 16"
                 >
                   <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0M4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5z" />

--- a/src/pages/Business.js
+++ b/src/pages/Business.js
@@ -20,16 +20,16 @@ const Business = () => {
               </h1>
               <Link
                 to="/signup"
-                class="text-white flex justify-center gap-5 items-center bg-gradient-to-r   from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-3 text-center "
+                className="text-white flex justify-center gap-5 items-center bg-gradient-to-r   from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-3 text-center "
               >
                 <span className="">Get Enroll</span>
                 <svg
-                  className=""
+                  
                   xmlns="http://www.w3.org/2000/svg"
                   width="16"
                   height="16"
                   fill="currentColor"
-                  class="bi bi-arrow-right-circle-fill"
+                  className="bi bi-arrow-right-circle-fill"
                   viewBox="0 0 16 16"
                 >
                   <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0M4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5z" />


### PR DESCRIPTION
This commit updates the class attribute to className in the Link components of the Bca, Bcom, and Business pages. It also adds missing whitespace characters before the closing bracket of the class attribute in some places.